### PR TITLE
Adjusting dispatcher for online actions and making it async

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,15 @@
+akka{
+
+  actor{
+    marvin-online-dispatcher{
+      type = Dispatcher
+      executor = "fork-join-executor"
+      fork-join-executor {
+        parallelism-min = 2
+        parallelism-factor = 2.0
+        parallelism-max = 15
+      }
+      throughput = 100
+    }
+  }
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,15 +1,31 @@
 akka{
 
-  actor{
-    marvin-online-dispatcher{
-      type = Dispatcher
-      executor = "fork-join-executor"
-      fork-join-executor {
-        parallelism-min = 2
-        parallelism-factor = 2.0
-        parallelism-max = 15
-      }
-      throughput = 100
-    }
+  # Loggers to register at boot time (akka.event.Logging$DefaultLogger logs
+  # to STDOUT)
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+
+  # Log level used by the configured loggers (see "loggers") as soon
+  # as they have been started; before that, see "stdout-loglevel"
+  # Options: OFF, ERROR, WARNING, INFO, DEBUG
+  loglevel = "DEBUG"
+
+  # Log level for the very basic logger activated during ActorSystem startup.
+  # This logger prints the log messages to stdout (System.out).
+  # Options: OFF, ERROR, WARNING, INFO, DEBUG
+  stdout-loglevel = "DEBUG"
+
+  # Filter of log events that is used by the LoggingAdapter before
+  # publishing log events to the eventStream.
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+}
+
+marvin-online-dispatcher{
+  type = Dispatcher
+  executor = "fork-join-executor"
+  fork-join-executor {
+    parallelism-min = 2
+    parallelism-factor = 2.0
+    parallelism-max = 24
   }
+  throughput = 100
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,22 +1,5 @@
 akka{
 
-  # Loggers to register at boot time (akka.event.Logging$DefaultLogger logs
-  # to STDOUT)
-  loggers = ["akka.event.slf4j.Slf4jLogger"]
-
-  # Log level used by the configured loggers (see "loggers") as soon
-  # as they have been started; before that, see "stdout-loglevel"
-  # Options: OFF, ERROR, WARNING, INFO, DEBUG
-  loglevel = "DEBUG"
-
-  # Log level for the very basic logger activated during ActorSystem startup.
-  # This logger prints the log messages to stdout (System.out).
-  # Options: OFF, ERROR, WARNING, INFO, DEBUG
-  stdout-loglevel = "DEBUG"
-
-  # Filter of log events that is used by the LoggingAdapter before
-  # publishing log events to the eventStream.
-  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 }
 
 marvin-online-dispatcher{
@@ -24,8 +7,8 @@ marvin-online-dispatcher{
   executor = "fork-join-executor"
   fork-join-executor {
     parallelism-min = 2
-    parallelism-factor = 2.0
-    parallelism-max = 24
+    parallelism-factor = 1
+    parallelism-max = 48
   }
   throughput = 100
 }

--- a/src/main/scala/org/marvin/executor/api/GenericHttpAPI.scala
+++ b/src/main/scala/org/marvin/executor/api/GenericHttpAPI.scala
@@ -307,7 +307,7 @@ trait GenericHttpAPI {
 
   def onlineExecute(actionName: String, params: String, message: String): Future[String] = {
     GenericHttpAPI.log.info(s"Request for $actionName] received.")
-    implicit val ec = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
+    implicit val ec = GenericHttpAPI.system.dispatchers.lookup("marvin-online-dispatcher")
     implicit val futureTimeout = GenericHttpAPI.onlineActionTimeout
     (GenericHttpAPI.actors(actionName) ? OnlineExecute(message, params)).mapTo[String]
   }


### PR DESCRIPTION
Online actions will now use a custom dispatcher configured via application.conf.

All online actions will use the async stub from grpc now.