### PR TITLE
fix save artifacts bug in pipeline actor

### DIFF
--- a/src/main/scala/org/marvin/executor/actions/PipelineAction.scala
+++ b/src/main/scala/org/marvin/executor/actions/PipelineAction.scala
@@ -60,7 +60,7 @@ class PipelineAction(metadata: EngineMetadata) extends Actor with ActorLogging{
 
         val futures:ListBuffer[Future[Done]] = ListBuffer[Future[Done]]()
 
-        for(artifactName <- engineActionMetadata.artifactsToLoad) {
+        for(artifactName <- engineActionMetadata.artifactsToPersist) {
           futures += (artifactSaver ? SaveToRemote(artifactName, protocol)).mapTo[Done]
         }
 


### PR DESCRIPTION
To test just run the pipeline action and check if all 4 artifacts are saved in hdfs:
 
- up the hadoop box
 - create a new engine
 - start http server
 - send a pipeline post (curl -H "Content-Type: application/json" -X POST http://localhost:8000/pipeline -d {})
- check in hdfs (http://localhost:50070/explorer.html)


