### PR TITLE
Fixing finite state machine locked on reloading

### DIFF
--- a/src/main/resources/EngineMetadataSchema.json
+++ b/src/main/resources/EngineMetadataSchema.json
@@ -58,9 +58,6 @@
     "hdfsHost": {
       "description": "HDFS host",
       "type": "string"
-    },
-    "actions": {
-      "$ref": "/EngineActionSchema.json"
     }
   },
   "required": ["name", "version", "engineType", "artifactsRemotePath", "artifactManagerType", "onlineActionTimeout", "healthCheckTimeout", "reloadTimeout", "batchActionTimeout", "pipelineActions", "actions"]

--- a/src/main/scala/org/marvin/executor/actions/OnlineAction.scala
+++ b/src/main/scala/org/marvin/executor/actions/OnlineAction.scala
@@ -31,8 +31,7 @@ import org.marvin.util.ProtocolUtil
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.reflect.ClassTag
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
 object OnlineAction {
   case class OnlineExecute(message: String, params: String)

--- a/src/main/scala/org/marvin/executor/actions/OnlineAction.scala
+++ b/src/main/scala/org/marvin/executor/actions/OnlineAction.scala
@@ -17,7 +17,7 @@
 package org.marvin.executor.actions
 
 import akka.Done
-import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import akka.actor.{Actor, ActorLogging, ActorRef, Props, Status}
 import akka.pattern.{ask, pipe}
 import akka.util.Timeout
 import org.marvin.executor.actions.OnlineAction.{OnlineExecute, OnlineHealthCheck, OnlineReload, OnlineReloadNoSave}
@@ -31,7 +31,8 @@ import org.marvin.util.ProtocolUtil
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.util.{Failure, Success}
+import scala.reflect.ClassTag
+import scala.util.{Failure, Success, Try}
 
 object OnlineAction {
   case class OnlineExecute(message: String, params: String)
@@ -77,14 +78,13 @@ class OnlineAction(actionName: String, metadata: EngineMetadata) extends Actor w
         futures += (artifactSaver ? SaveToLocal(artifactName, splitedProtocols(artifactName)))
       }
 
-      Future.sequence(futures).onComplete {
-        case Success(response) =>
-          log.info(s"Reload to $actionName completed [$response] ! Protocol: [$protocol]")
-
-          onlineActionProxy forward Reload(protocol)
-
-        case Failure(failure) =>
-          failure.printStackTrace()
+      val origSender = sender()
+      Future.sequence(futures).onComplete{
+        case Success(_) => onlineActionProxy.ask(Reload(protocol)) pipeTo origSender
+        case Failure(e) => {
+          log.error(s"Failure to reload artifacts using protocol $protocol.")
+          origSender ! Status.Failure(e)
+        }
       }
 
     case OnlineReloadNoSave(protocol) =>

--- a/src/test/resources/EngineMetadataSchema.json
+++ b/src/test/resources/EngineMetadataSchema.json
@@ -58,9 +58,6 @@
     "hdfsHost": {
       "description": "HDFS host",
       "type": "string"
-    },
-    "actions": {
-      "$ref": "file:src/test/resources/EngineActionSchema.json"
     }
   },
   "required": ["name", "version", "engineType", "artifactsRemotePath", "artifactManagerType", "onlineActionTimeout", "healthCheckTimeout", "reloadTimeout", "batchActionTimeout", "pipelineActions", "actions"]

--- a/src/test/scala/org/marvin/executor/actions/OnlineActionTest.scala
+++ b/src/test/scala/org/marvin/executor/actions/OnlineActionTest.scala
@@ -28,6 +28,8 @@ import org.marvin.model.EngineMetadata
 import org.marvin.testutil.MetadataMock
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
+import scala.concurrent.duration._
+
 class OnlineActionTest extends TestKit(
   ActorSystem("OnlineActionTest", ConfigFactory.parseString("""akka.loggers = ["akka.testkit.TestEventListener"]""")))
   with ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll {
@@ -85,6 +87,8 @@ class OnlineActionTest extends TestKit(
       mockedSaver.expectMsg(SaveToLocal("model", protocol))
       mockedSaver.reply(Done)
 
+      //wait for one message to be returned for at least 3 seconds
+      receiveOne(3 seconds)
       mockedProxy.expectMsg(Reload(protocol))
       mockedProxy.reply(Reloaded(protocol))
     }

--- a/src/test/scala/org/marvin/executor/statemachine/PredictorFSMTest.scala
+++ b/src/test/scala/org/marvin/executor/statemachine/PredictorFSMTest.scala
@@ -71,7 +71,7 @@ class PredictorFSMTest extends TestKit(
       returnedMessage.cause shouldBe a[MarvinEExecutorException]
     }
 
-    "go to Reloaded when Reloading and receive Reloaded" in {
+    "go to Ready when Reloading and receive Reloaded" in {
       val probe = TestProbe()
       val fsm = TestFSMRef[State, Data, PredictorFSM](new PredictorFSM(probe.ref, MetadataMock.simpleMockedMetadata()))
       fsm.setState(Reloading)


### PR DESCRIPTION
The OnlineAction was modified to correctly send the message to the FSM when Reloading artifacts.

This PR fixes #36 

Steps to test:
 - Clone this branch and run "sbt assembly".
 - Start the engine-httpserver specifying the brand new compiled jar.
 - Perform a pipeline (to generate a protocol)
 - Perform a predictor/reload using the protocol generated during pipeline.
 - Perform a predict.
 - Verify that the model related with the protocol was used. 