### PR TITLE
Json schema bug fix

### DIFF
--- a/src/main/resources/EngineMetadataSchema.json
+++ b/src/main/resources/EngineMetadataSchema.json
@@ -60,7 +60,7 @@
       "type": "string"
     },
     "actions": {
-      "$ref": "file:src/main/resources/EngineActionSchema.json"
+      "$ref": "/EngineActionSchema.json"
     }
   },
   "required": ["name", "version", "engineType", "artifactsRemotePath", "artifactManagerType", "onlineActionTimeout", "healthCheckTimeout", "reloadTimeout", "batchActionTimeout", "pipelineActions", "actions"]

--- a/src/test/resources/EngineActionSchema.json
+++ b/src/test/resources/EngineActionSchema.json
@@ -1,0 +1,42 @@
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "description": "Engine action name",
+        "type": "string"
+      },
+      "actionType": {
+        "description": "Engine action type",
+        "type": "string"
+      },
+      "port": {
+        "description": "Engine action port",
+        "type": "integer"
+      },
+      "host": {
+        "description": "host name",
+        "type": "string"
+      },
+      "artifactsToPersist": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "artifactsToLoad": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "required": [
+      "name",
+      "actionType",
+      "port",
+      "host"
+    ]
+  }
+}

--- a/src/test/resources/EngineMetadataSchema.json
+++ b/src/test/resources/EngineMetadataSchema.json
@@ -60,7 +60,7 @@
       "type": "string"
     },
     "actions": {
-      "$ref": "file:src/main/resources/EngineActionSchema.json"
+      "$ref": "file:src/test/resources/EngineActionSchema.json"
     }
   },
   "required": ["name", "version", "engineType", "artifactsRemotePath", "artifactManagerType", "onlineActionTimeout", "healthCheckTimeout", "reloadTimeout", "batchActionTimeout", "pipelineActions", "actions"]

--- a/src/test/resources/EngineMetadataSchema.json
+++ b/src/test/resources/EngineMetadataSchema.json
@@ -1,0 +1,67 @@
+{
+  "title": "Metadata Schema",
+  "description": "Schema for Engine Metadata validation",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "Engine name",
+      "type": "string"
+    },
+    "version": {
+      "description": "Engine version",
+      "type": "string"
+    },
+    "engineType": {
+      "description": "Engine type",
+      "type": "string"
+    },
+    "artifactsRemotePath": {
+      "description": "Artifacts remote path",
+      "type": "string"
+    },
+    "artifactManagerType": {
+      "description": "Artifacts manager path",
+      "type": "string"
+    },
+    "s3BucketName": {
+      "description": "Amazon S3 bucket name",
+      "type": "string"
+    },
+    "pipelineActions": {
+      "description": "Pipeline actions",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "additionalItems": false
+    },
+    "onlineActionTimeout": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "healthCheckTimeout": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "reloadTimeout": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "reloadStateTimeout": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "batchActionTimeout": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "hdfsHost": {
+      "description": "HDFS host",
+      "type": "string"
+    },
+    "actions": {
+      "$ref": "file:src/main/resources/EngineActionSchema.json"
+    }
+  },
+  "required": ["name", "version", "engineType", "artifactsRemotePath", "artifactManagerType", "onlineActionTimeout", "healthCheckTimeout", "reloadTimeout", "batchActionTimeout", "pipelineActions", "actions"]
+}

--- a/src/test/scala/org/marvin/util/JsonUtilTest.scala
+++ b/src/test/scala/org/marvin/util/JsonUtilTest.scala
@@ -48,4 +48,16 @@ class JsonUtilTest extends WordSpec with Matchers {
     }
   }
 
+  "Schema files in main resource and test resource" should {
+    "synchronize" in {
+      val testSchema = Source.fromResource("EngineMetadataSchema.json").getLines().filterNot(line => line.trim.startsWith("\"$ref\":")).toList
+      val mainSchema = Source.fromFile("src/main/resources/EngineMetadataSchema.json").getLines().filterNot(line => line.trim.startsWith("\"$ref\":")).toList
+      assert { testSchema === mainSchema }
+
+      val testActionSchema = Source.fromResource("EngineActionSchema.json").getLines().toList
+      val mainActionSchema = Source.fromFile("src/main/resources/EngineActionSchema.json").getLines().toList
+      assert { testActionSchema === mainActionSchema }
+    }
+  }
+
 }


### PR DESCRIPTION
referring to #39 

Json Schema reference was working fine in IDE with your file path, but when packed up in JAR, all resource files lost your file path structure and SchemaLoader can not find those files from your original path.

In this fix, i changed schema file´s reference path to get the JAR back to work and copied the old schema files to src/test/resource to keep unit tests working