### PR TITLE
Feedback Action added

### DIFF
--- a/src/test/resources/valid.metadata
+++ b/src/test/resources/valid.metadata
@@ -50,5 +50,13 @@
 		"artifactsToPersist": [],
 		"artifactsToLoad": ["model", "metrics"],
 		"pipeline": ["ppreparator"]
-	}]
+	}, {
+   		"name": "feedback",
+   		"actionType": "online",
+   		"port": 50056,
+   		"host": "localhost",
+   		"artifactsToPersist": [],
+   		"artifactsToLoad": [],
+   		"pipeline": []
+   	}]
 }

--- a/src/test/scala/org/marvin/testutil/MetadataMock.scala
+++ b/src/test/scala/org/marvin/testutil/MetadataMock.scala
@@ -28,7 +28,8 @@ object MetadataMock {
         new EngineActionMetadata(name="acquisitor", actionType="batch", port=778, host="localhost", artifactsToPersist=List("initial_dataset"), artifactsToLoad=List()),
         new EngineActionMetadata(name="tpreparator", actionType="batch", port=779, host="localhost", artifactsToPersist=List("dataset"), artifactsToLoad=List("initial_dataset")),
         new EngineActionMetadata(name="trainer", actionType="batch", port=780, host="localhost", artifactsToPersist=List("model"), artifactsToLoad=List("dataset")),
-        new EngineActionMetadata(name="evaluator", actionType="batch", port=781, host="localhost", artifactsToPersist=List("metrics"), artifactsToLoad=List("dataset", "model"))
+        new EngineActionMetadata(name="evaluator", actionType="batch", port=781, host="localhost", artifactsToPersist=List("metrics"), artifactsToLoad=List("dataset", "model")),
+        new EngineActionMetadata(name="feedback", actionType="online", port=782, host="localhost", artifactsToPersist=List(), artifactsToLoad=List())
       ),
       artifactsRemotePath = "",
       artifactManagerType = "HDFS",


### PR DESCRIPTION
New onlineAction(feedback) added to executor.
Changes:
1. New onlineAction actor instantiated for feedback action.
2. Code restructuring for feedback action.
3. Metadata file update
4. Unit test added
--------------------------------------------------------------------------------------------------------
Tests:
1. Switch python-tool-box to branch feedback_api.
2. Generate new engine from toolbox.
3. Bring up grpc server from new engine.
4. Run GenericHttpAPI from engine-executor
5. Send POST requests (pipeline or feedback)
