### PR TITLE
Protocol error handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ before_script:
 
 script: sbt ++$TRAVIS_SCALA_VERSION coverage test coverageReport
 
+bundler_args: --retry 5
+
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 

--- a/src/main/scala/org/marvin/artifact/manager/ArtifactFSSaver.scala
+++ b/src/main/scala/org/marvin/artifact/manager/ArtifactFSSaver.scala
@@ -45,8 +45,8 @@ class ArtifactFSSaver(metadata: EngineMetadata) extends Actor with ActorLogging 
     log.info(s"File ${destination} saved!")
   }
 
-  def validProtocol(protocol: Path): Boolean = {
-    new java.io.File(protocol.toString).exists
+  def validatePath(path: Path): Boolean = {
+    new java.io.File(path.toString).exists
   }
 
   override def receive: Receive = {
@@ -55,10 +55,10 @@ class ArtifactFSSaver(metadata: EngineMetadata) extends Actor with ActorLogging 
       val uris = generatePaths(artifactName, protocol)
 
       // Validate if the protocol is correct
-      if (!validProtocol(uris("remotePath")))
-        log.error(s"Invalid protocol: ${protocol}, reload action canceled!")
-      else
+      if (validatePath(uris("remotePath")))
         copyFile(uris("remotePath"), uris("localPath"))
+      else
+        log.error(s"Invalid protocol: ${protocol}, reload action canceled!")
 
       sender ! Done
 
@@ -67,10 +67,10 @@ class ArtifactFSSaver(metadata: EngineMetadata) extends Actor with ActorLogging 
       val uris = generatePaths(artifactName, protocol)
 
       // Validate if the protocol is correct
-      if (!validProtocol(uris("localPath")))
-        log.error(s"Invalid protocol: ${protocol}, reload action canceled!")
-      else
+      if (validatePath(uris("localPath")))
         copyFile(uris("localPath"), uris("remotePath"))
+      else
+        log.error(s"Invalid protocol: ${protocol}, reload action canceled!")
 
       sender ! Done
 

--- a/src/main/scala/org/marvin/artifact/manager/ArtifactFSSaver.scala
+++ b/src/main/scala/org/marvin/artifact/manager/ArtifactFSSaver.scala
@@ -58,7 +58,7 @@ class ArtifactFSSaver(metadata: EngineMetadata) extends Actor with ActorLogging 
       if (validatePath(uris("remotePath")))
         copyFile(uris("remotePath"), uris("localPath"))
       else
-        log.error(s"Invalid protocol: ${protocol}, reload action canceled!")
+        log.error(s"Invalid protocol: ${protocol}, save process canceled!")
 
       sender ! Done
 
@@ -70,7 +70,7 @@ class ArtifactFSSaver(metadata: EngineMetadata) extends Actor with ActorLogging 
       if (validatePath(uris("localPath")))
         copyFile(uris("localPath"), uris("remotePath"))
       else
-        log.error(s"Invalid protocol: ${protocol}, reload action canceled!")
+        log.error(s"Invalid protocol: ${protocol}, save process canceled!")
 
       sender ! Done
 

--- a/src/main/scala/org/marvin/artifact/manager/ArtifactFSSaver.scala
+++ b/src/main/scala/org/marvin/artifact/manager/ArtifactFSSaver.scala
@@ -45,12 +45,20 @@ class ArtifactFSSaver(metadata: EngineMetadata) extends Actor with ActorLogging 
     log.info(s"File ${destination} saved!")
   }
 
+  def validProtocol(protocol: Path): Boolean = {
+    new java.io.File(protocol.toString).exists
+  }
+
   override def receive: Receive = {
     case SaveToLocal(artifactName, protocol) =>
       log.info("Receive message and starting to working...")
       val uris = generatePaths(artifactName, protocol)
 
-      copyFile(uris("remotePath"), uris("localPath"))
+      // Validate if the protocol is correct
+      if (!validProtocol(uris("remotePath")))
+        log.error(s"Invalid protocol: ${protocol}, reload action canceled!")
+      else
+        copyFile(uris("remotePath"), uris("localPath"))
 
       sender ! Done
 
@@ -58,7 +66,11 @@ class ArtifactFSSaver(metadata: EngineMetadata) extends Actor with ActorLogging 
       log.info("Receive message and starting to working...")
       val uris = generatePaths(artifactName, protocol)
 
-      copyFile(uris("localPath"), uris("remotePath"))
+      // Validate if the protocol is correct
+      if (!validProtocol(uris("localPath")))
+        log.error(s"Invalid protocol: ${protocol}, reload action canceled!")
+      else
+        copyFile(uris("localPath"), uris("remotePath"))
 
       sender ! Done
 

--- a/src/main/scala/org/marvin/artifact/manager/ArtifactHdfsSaver.scala
+++ b/src/main/scala/org/marvin/artifact/manager/ArtifactHdfsSaver.scala
@@ -80,7 +80,7 @@ class ArtifactHdfsSaver(metadata: EngineMetadata) extends Actor with ActorLoggin
         log.info(s"File ${uris("localPath")} saved!")
       }
       else {
-        log.error(s"Invalid protocol: ${protocol}, reload action canceled!")
+        log.error(s"Invalid protocol: ${protocol}, save process canceled!")
       }
 
       sender ! Done
@@ -97,7 +97,7 @@ class ArtifactHdfsSaver(metadata: EngineMetadata) extends Actor with ActorLoggin
         log.info(s"File ${uris("localPath")} saved!")
       }
       else {
-        log.error(s"Invalid protocol: ${protocol}, reload action canceled!")
+        log.error(s"Invalid protocol: ${protocol}, save process canceled!")
       }
 
       sender ! Done

--- a/src/main/scala/org/marvin/artifact/manager/ArtifactS3Saver.scala
+++ b/src/main/scala/org/marvin/artifact/manager/ArtifactS3Saver.scala
@@ -71,7 +71,7 @@ class ArtifactS3Saver(metadata: EngineMetadata) extends Actor with ActorLogging 
         log.info(s"File ${uris("localPath")} saved!")
       }
       else {
-        log.error(s"Invalid protocol: ${protocol}, reload action canceled!")
+        log.error(s"Invalid protocol: ${protocol}, save process canceled!")
       }
 
       sender ! Done
@@ -89,7 +89,7 @@ class ArtifactS3Saver(metadata: EngineMetadata) extends Actor with ActorLogging 
         log.info(s"File ${uris("localPath")} saved!")
       }
       else {
-        log.error(s"Invalid protocol: ${protocol}, reload action canceled!")
+        log.error(s"Invalid protocol: ${protocol}, save process canceled!")
       }
 
       sender ! Done

--- a/src/test/scala/org/marvin/artifact/manager/ArtifactS3SaverTest.scala
+++ b/src/test/scala/org/marvin/artifact/manager/ArtifactS3SaverTest.scala
@@ -1,10 +1,12 @@
 package org.marvin.artifact.manager
 
 import java.io.File
+
 import akka.Done
 import akka.actor.{ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestKit}
 import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.GetObjectRequest
 import com.typesafe.config.ConfigFactory
 import org.apache.hadoop.fs.Path
 import org.marvin.artifact.manager.ArtifactSaver.{SaveToLocal, SaveToRemote}
@@ -26,12 +28,12 @@ class ArtifactS3SaverTest extends TestKit(
     "receive SaveToLocal message" in {
       val metadata = MetadataMock.simpleMockedMetadata()
       val _s3Client = mock[AmazonS3]
-      val actor = system.actorOf(Props(new ArtifactS3SaverMock(metadata, _s3Client, "TRUE")))
+      val actor = system.actorOf(Props(new ArtifactS3SaverMock(metadata, _s3Client, true)))
 
       val protocol = "protocol"
       val artifactName = "model"
 
-      (_s3Client.doesObjectExist(_ : String, _ : String)).expects(*, *).once()
+      (_s3Client.getObject(_ : GetObjectRequest, _ : File)).expects(*, *).once()
 
       actor ! SaveToLocal(artifactName, protocol)
 
@@ -41,7 +43,7 @@ class ArtifactS3SaverTest extends TestKit(
     "receive SaveToRemote message" in {
       val metadata = MetadataMock.simpleMockedMetadata()
       val _s3Client = mock[AmazonS3]
-      val actor = system.actorOf(Props(new ArtifactS3SaverMock(metadata, _s3Client, "TRUE")))
+      val actor = system.actorOf(Props(new ArtifactS3SaverMock(metadata, _s3Client, true)))
 
       val protocol = "protocol"
       val artifactName = "model"
@@ -65,14 +67,14 @@ class ArtifactS3SaverTest extends TestKit(
       }
     }
 
-  class ArtifactS3SaverMock(metadata: EngineMetadata, _s3Client: AmazonS3, _protocol: String) extends ArtifactS3Saver(metadata) {
+  class ArtifactS3SaverMock(metadata: EngineMetadata, _s3Client: AmazonS3, _isRemote: Boolean) extends ArtifactS3Saver(metadata) {
     def _preStart(): Unit = super.preStart()
     override def preStart(): Unit = {
       s3Client = _s3Client
     }
 
-    override def validProtocol(protocol: Path): Boolean = {
-      if ( _protocol == "TRUE") true
+    override def validatePath(path: Path, isRemote: Boolean): Boolean = {
+      if (_isRemote) true
       else false
     }
   }

--- a/src/test/scala/org/marvin/fixtures/MetadataMock.scala
+++ b/src/test/scala/org/marvin/fixtures/MetadataMock.scala
@@ -34,14 +34,14 @@ object MetadataMock {
       artifactsRemotePath = "",
       artifactManagerType = "HDFS",
       s3BucketName = "marvin-artifact-bucket",
-      batchActionTimeout = 100,
+      batchActionTimeout = 2000,
       engineType = "python",
       hdfsHost = "",
-      healthCheckTimeout = 100,
-      onlineActionTimeout = 100,
+      healthCheckTimeout = 2000,
+      onlineActionTimeout = 2000,
       pipelineActions = List("acquisitor", "tpreparator"),
       reloadStateTimeout = Some(500),
-      reloadTimeout = 100,
+      reloadTimeout = 2000,
       version = "1"
     )
   }


### PR DESCRIPTION
Bug fix referring #66 

Fixs in local file system, AWS S3 bucket, Hadoop file system.

For tests:

Run Pipeline action first, copy the result protocol, pass it wrong in Predictor  Preparation action.
Engine executor should show error log with message like: "Invalid protocol: pipeline_336a66ca-4969-4e6e-a30d-b7756dd148d, reload action canceled!"

Pass the same protocol again correctly, and perform Predict action, the Predictor should be able to do your job instead of showing error message.


For AWS S3 test, set artifactManagerType in engine metadata to "S3", add s3BucketName key, and don't forget to set environment variables: 
AWS_ACCESS_KEY_ID, 
AWS_SECRET_ACCESS_KEY, 
AWS_DEFAULT_REGION

For Hadoop test, set artifactManagerType to "HDFS", add hdfsHost key, and don't forget to set environment variables:
HADOOP_CONF_DIR